### PR TITLE
Add support for InfluxTarget

### DIFF
--- a/defaults/InfluxTarget.dhall
+++ b/defaults/InfluxTarget.dhall
@@ -1,0 +1,3 @@
+let InfluxTarget = ../types/InfluxTarget.dhall
+
+in  { rawQuery = True, resultFormat = "time_series", policy = "value" }

--- a/package.dhall
+++ b/package.dhall
@@ -29,6 +29,10 @@
     { default = ./defaults/PrometheusTarget.dhall
     , Type = (./types/PrometheusTarget.dhall).Type
     }
+, InfluxTarget =
+    { default = ./defaults/InfluxTarget.dhall
+    , Type = (./types/InfluxTarget.dhall).Type
+    }
 , TestDataDBTarget =
     { default = ./defaults/TestDataDBTarget.dhall
     , Type = (./types/TestDataDBTarget.dhall).Type

--- a/types/InfluxTarget.dhall
+++ b/types/InfluxTarget.dhall
@@ -1,0 +1,18 @@
+let InfluxGroup = { params : List Text, type : Text }
+
+let InfluxTag = { key : Text, operator : Text, value : Text }
+
+let InfluxTarget =
+      { groupBy : List InfluxGroup
+      , select : List (List InfluxGroup)
+      , measurement : Text
+      , orderByTime : Text
+      , policy : Text
+      , resultFormat : Text
+      , refId : Text
+      , query : Text
+      , rawQuery : Bool
+      , tags : List InfluxTag
+      }
+
+in  { Type = InfluxTarget, InfluxGroup, InfluxTag }

--- a/types/MetricTargets.dhall
+++ b/types/MetricTargets.dhall
@@ -1,6 +1,8 @@
 let PrometheusTarget = (./PrometheusTarget.dhall).Type
+let InfluxTarget = (./InfluxTarget.dhall).Type
 let TestDataDBTarget = (./TestDataDBTarget.dhall).Type
 in
 < PrometheusTarget : PrometheusTarget
+| InfluxTarget : InfluxTarget
 | TestDataDBTarget : TestDataDBTarget
 >


### PR DESCRIPTION
This change adds a new InfluxTarget MetricTarget to support adding
influx db metrics.