### PR TITLE
Remove Influx raw query and add example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,3 +33,7 @@ jobs:
       run: |
         echo "Building examples/consul_exporter.dhall"
         ./dhall-to-json --file examples/consul_exporter.dhall
+    - name: Build examples/influxdb.dhall
+      run: |
+        echo "Building examples/influxdb.dhall"
+        ./dhall-to-json --file examples/influxdb.dhall

--- a/defaults/InfluxTarget.dhall
+++ b/defaults/InfluxTarget.dhall
@@ -1,3 +1,1 @@
-let InfluxTarget = ../types/InfluxTarget.dhall
-
-in  { rawQuery = True, resultFormat = "time_series", policy = "value" }
+{ orderByTime = "DESC", resultFormat = "time_series", policy = "default" }

--- a/examples/influxdb.dhall
+++ b/examples/influxdb.dhall
@@ -1,0 +1,42 @@
+let Grafana = ../package.dhall
+
+let gauge =
+      \(measurement : Text) ->
+        Grafana.MetricsTargets.InfluxTarget
+          { groupBy =
+            [ { type = "time", params = [ "\$__interval" ] }
+            , { type = "fill", params = [ "previous" ] }
+            ]
+          , measurement
+          , orderByTime = "ASC"
+          , policy = "default"
+          , refId = "A"
+          , alias = measurement
+          , resultFormat = "time_series"
+          , select =
+            [ [ { type = "field", params = [ "value" ] }
+              , { type = "distinct", params = [] : List Text }
+              ]
+            ]
+          , tags = [ { key = "metric_type", operator = "=", value = "gauge" } ]
+          }
+
+let resource-panel =
+      \(title : Text) ->
+      \(measurement : Text) ->
+        Grafana.Panels.mkGraphPanel
+          Grafana.GraphPanel::{
+          , title
+          , gridPos = { x = 0, y = 1, w = 24, h = 8 }
+          , targets = [ gauge measurement ]
+          }
+
+let dashboard =
+      Grafana.Dashboard::{
+      , title = "InfluxDB metrics"
+      , uid = Some "influxdb_metrics"
+      , panels =
+          Grafana.Utils.generateIds [ resource-panel "CPU" "zuul.local.cores" ]
+      }
+
+in  dashboard

--- a/types/InfluxTarget.dhall
+++ b/types/InfluxTarget.dhall
@@ -10,9 +10,8 @@ let InfluxTarget =
       , policy : Text
       , resultFormat : Text
       , refId : Text
-      , query : Text
-      , rawQuery : Bool
       , tags : List InfluxTag
+      , alias : Text
       }
 
 in  { Type = InfluxTarget, InfluxGroup, InfluxTag }


### PR DESCRIPTION
This change removes the raw query attributes for Influx because it
conflicts with the other attributes. Moreover it is safer and easier
to compose query using the custom attributes.

This change also adds an example usage.