### PR TITLE
Export StatPanel Options to enable record completion

### DIFF
--- a/defaults/StatPanel.dhall
+++ b/defaults/StatPanel.dhall
@@ -2,15 +2,6 @@ let StatPanel = ../types/StatPanel.dhall
 let MetricTargets = ../types/MetricTargets.dhall
 let Link = ../types/Link.dhall
 
-let Options =
-    { colorMode = StatPanel.ColorMode.background
-    , graphMode = StatPanel.GraphMode.area
-    , justifyMode = StatPanel.JustifyMode.auto
-    , orientation = StatPanel.Orientation.auto
-    , reduceOptions = { calcs = [ StatPanel.CalcMode.mean ], fields = "", values = False }
-    , textMode = StatPanel.TextMode.auto
-    }
-
 let StatPanel =
     { type = StatPanel.PanelType.stat
     , alert = None (../types/Alert.dhall).Type
@@ -22,7 +13,7 @@ let StatPanel =
     , transparent = False
     , timeFrom = None Text
     , timeShift = None Text
-    , options = Options
+    , options = ./StatPanelOptions.dhall
     , colorPostfix = None Bool
     , colorPrefix = None Bool
     , datasource = None Text

--- a/defaults/StatPanelOptions.dhall
+++ b/defaults/StatPanelOptions.dhall
@@ -1,0 +1,13 @@
+let StatPanelOptions = ../types/StatPanelOptions.dhall
+
+in  { colorMode = StatPanelOptions.ColorMode.background
+    , graphMode = StatPanelOptions.GraphMode.area
+    , justifyMode = StatPanelOptions.JustifyMode.auto
+    , orientation = StatPanelOptions.Orientation.auto
+    , reduceOptions =
+      { calcs = [ StatPanelOptions.CalcMode.mean ]
+      , fields = ""
+      , values = False
+      }
+    , textMode = StatPanelOptions.TextMode.auto
+    }

--- a/examples/consul_exporter.dhall
+++ b/examples/consul_exporter.dhall
@@ -37,6 +37,9 @@ let panels =
                     ([] : List ({ color : Text, value : Double }))
 
                 }
+            , options = Grafana.StatPanelOptions::
+                { orientation = Grafana.StatPanelOptions.Orientation.horizontal
+                }
             }
         )
     , Grafana.Panels.mkGraphPanel

--- a/package.dhall
+++ b/package.dhall
@@ -7,6 +7,9 @@
     { default = ./defaults/SinglestatPanel.dhall
     , Type = (./types/SinglestatPanel.dhall).Type
     }
+, StatPanelOptions =
+    ./types/StatPanelOptions.dhall //
+    { default = ./defaults/StatPanelOptions.dhall }
 , StatPanel =
     { default = (./defaults/StatPanel.dhall).StatPanel
     , Type = (./types/StatPanel.dhall).Type

--- a/types/StatPanel.dhall
+++ b/types/StatPanel.dhall
@@ -1,26 +1,6 @@
 let PanelType = < stat >
 let NullPointMode = < null | connected | `null as zero` >
 
-let ColorMode = < value | background >
-let GraphMode = < none | area >
-let JustifyMode = < auto | center >
-let Orientation = < auto | horizontal | vertical >
-let TextMode = < auto | value | value_and_name | name | none >
-let CalcMode = < lastNotNull | last | firstNotNull | first | min | max | mean | total | count | range | delta | step | diff | logmin | allIsZero | allIsNull | changeCount | distinctCount >
-
-let Options =
-    { colorMode : ColorMode
-    , graphMode : GraphMode
-    , justifyMode : JustifyMode
-    , orientation : Orientation
-    , reduceOptions :
-        { calcs : List CalcMode
-        , fields : Text
-        , values : Bool
-        }
-    , textMode : TextMode
-    }
-
 let StatPanel =
     ./BasePanel.dhall //\\
     { type : PanelType
@@ -28,7 +8,7 @@ let StatPanel =
     , targets : List ./MetricTargets.dhall
     , timeFrom : Optional Text
     , timeShift : Optional Text
-    , options : Options
+    , options : (./StatPanelOptions.dhall).Type
     , maxDataPoints : Natural
     -- , interval : Optional Text
     -- , cacheTimeout : Optional Text
@@ -68,26 +48,9 @@ let StatPanel =
     , colorPostfix : Optional Bool
     }
 
-let mkOptions =
-    { colorMode = ColorMode.background
-    , graphMode = GraphMode.area
-    , justifyMode = JustifyMode.auto
-    , orientation = Orientation.auto
-    , reduceOptions = { calcs = [ CalcMode.mean ], fields = "", values = False }
-    , textMode = TextMode.auto
-    }
-
 in
 
 { Type = StatPanel
 , PanelType
 , NullPointMode
-, ColorMode
-, GraphMode
-, JustifyMode
-, Orientation
-, TextMode
-, CalcMode
-, Options
-, mkOptions
 }

--- a/types/StatPanelOptions.dhall
+++ b/types/StatPanelOptions.dhall
@@ -1,0 +1,47 @@
+let ColorMode = < value | background >
+
+let GraphMode = < none | area >
+
+let JustifyMode = < auto | center >
+
+let Orientation = < auto | horizontal | vertical >
+
+let TextMode = < auto | value | value_and_name | name | none >
+
+let CalcMode =
+      < lastNotNull
+      | last
+      | firstNotNull
+      | first
+      | min
+      | max
+      | mean
+      | total
+      | count
+      | range
+      | delta
+      | step
+      | diff
+      | logmin
+      | allIsZero
+      | allIsNull
+      | changeCount
+      | distinctCount
+      >
+
+in  { ColorMode
+    , GraphMode
+    , JustifyMode
+    , Orientation
+    , CalcMode
+    , TextMode
+    , Type =
+        { colorMode : ColorMode
+        , graphMode : GraphMode
+        , justifyMode : JustifyMode
+        , orientation : Orientation
+        , reduceOptions :
+            { calcs : List CalcMode, fields : Text, values : Bool }
+        , textMode : TextMode
+        }
+    }


### PR DESCRIPTION
The StatPanel.options type is not exported by the main package,
making it difficult to configure.

This change adds a proper record completion for the StatPanelOptions,
so that the options can be easily set by user.