### PR TITLE
Expose templatingvariables so that they can be used with record auto-completion, without using the smart constructors

### DIFF
--- a/defaults/TemplatingVariable.dhall
+++ b/defaults/TemplatingVariable.dhall
@@ -7,6 +7,7 @@ let map = Prelude.List.map
 
 let concatSep = Prelude.Text.concatSep
 
+let TemplatingVariable = (../types/TemplatingVariable.dhall)
 let Templating = (../types/TemplatingVariable.dhall).Types
 
 let VariableType = (../types/TemplatingVariable.dhall).VariableType
@@ -231,19 +232,41 @@ let mkAdHoc =
         Templating.AdHocVariable
           (adHocValue ⫽ { name, filters, hide = hide _hide })
 
-in  { QueryVariable
-    , mkQuery
-    , IntervalVariable
-    , mkInterval
-    , DatasourceVariable
-    , mkDatasource
-    , CustomVariable
-    , mkCustom
-    , ConstantVariable
-    , mkConstant
-    , TextboxVariable
-    , mkTextbox
-    , AdHocVariable
-    , mkAdHoc
-    , hide
-    }
+in
+{ QueryVariable =
+      { Type = TemplatingVariable.QueryVariable
+      , default = queryValue
+      }
+, mkQuery
+, IntervalVariable =
+      { Type = TemplatingVariable.IntervalVariable
+      , default = intervalValue
+      }
+, mkInterval
+, DatasourceVariable =
+      { Type = TemplatingVariable.DatasourceVariable
+      , default = datasourceValue
+      }
+, mkDatasource
+, CustomVariable =
+      { Type = TemplatingVariable.CustomVariable
+      , default = customValue
+      }
+, mkCustom
+, ConstantVariable =
+      { Type = TemplatingVariable.ConstantVariable
+      , default = constantValue
+      }
+, mkConstant
+, TextboxVariable =
+      { Type = TemplatingVariable.TextboxVariable
+      , default = textboxValue
+      }
+, mkTextbox
+, AdHocVariable =
+      { Type = TemplatingVariable.AdHocVariable
+      , default = adHocValue
+      }
+, mkAdHoc
+, hide
+}

--- a/types/TemplatingVariable.dhall
+++ b/types/TemplatingVariable.dhall
@@ -1,4 +1,4 @@
-let VariableType = 
+let VariableType =
     < query
     | datasource
     | interval
@@ -17,14 +17,14 @@ let TemplatingVariableBase =
     , name: Text
     , skipUrlSync: Bool
     {-
-    , tagValuesQuery: 
+    , tagValuesQuery:
     , tags: []
-    , tagsQuery: 
+    , tagsQuery:
     -}
     , type : VariableType
     }
 
-let QueryVariable = 
+let QueryVariable =
     TemplatingVariableBase //\\
     { query: Text
     , allValue: Optional Text
@@ -32,7 +32,7 @@ let QueryVariable =
     , multi: Bool
     , regex: Text
     , sort: Natural
-    , refresh : Natural 
+    , refresh : Natural
     , options: List Option
     , datasource: Text
     , current: Optional Current
@@ -89,7 +89,7 @@ let AdHocVariable =
     , datasource : Text
     }
 
-let Types = 
+let Types =
     < QueryVariable : QueryVariable
     | IntervalVariable : IntervalVariable
     | DatasourceVariable : DatasourceVariable
@@ -105,4 +105,11 @@ in
 , VariableType = VariableType
 , Current
 , Option
+, QueryVariable
+, IntervalVariable
+, DatasourceVariable
+, CustomVariable
+, ConstantVariable
+, TextboxVariable
+, AdHocVariable
 }


### PR DESCRIPTION
Can be used like this:

```
    Grafana.Dashboard::
        { templating = { list = [Grafana.TemplatingVariable.Types.DatasourceVariable Grafana.TemplatingVariableUtils.DatasourceVariable::{ name = "foo" }] }
        }
```