### PR TITLE
Rename TimeZone into Timezone to support dhall>=21

### DIFF
--- a/defaults/Dashboard.dhall
+++ b/defaults/Dashboard.dhall
@@ -8,7 +8,7 @@ in
 , title = "Title"
 , tags = [] : List Text
 , style = Dashboard.Style.dark
-, timezone = Some Dashboard.TimeZone.utc
+, timezone = Some Dashboard.Timezone.utc
 , editable = False
 , hideControls = False
 , graphTooltip = 0

--- a/package.dhall
+++ b/package.dhall
@@ -69,7 +69,7 @@
     { default = ./defaults/GridPos.dhall
     , Type = ./types/GridPos.dhall
     }
-, TimeZone = (./types/Dashboard.dhall).TimeZone
+, Timezone = (./types/Dashboard.dhall).Timezone
 , Transformations =
     { default = (./types/Transformations.dhall).Types.Organize
     , Type = (./types/Transformations.dhall).Types

--- a/types/Dashboard.dhall
+++ b/types/Dashboard.dhall
@@ -28,5 +28,5 @@ in
 
 { Type = Dashboard
 , Style = Style
-, TimeZone = TimeZoneOption
+, Timezone = TimeZoneOption
 }


### PR DESCRIPTION
… because TimeZone is now a reserved keyword:

  https://github.com/dhall-lang/dhall-lang/releases/tag/v21.0.0